### PR TITLE
Update ldas.py

### DIFF
--- a/src/tsgettoolbox/functions/ldas.py
+++ b/src/tsgettoolbox/functions/ldas.py
@@ -32,6 +32,7 @@ import async_retriever as ar
 import pandas as pd
 import requests
 from requests.auth import HTTPBasicAuth
+import json
 
 # from pandas._libs.lib import no_default
 from tabulate import tabulate as tb
@@ -1141,8 +1142,10 @@ def base_ldas(
             netrc.netrc().hosts["urs.earthdata.nasa.gov"][2],
         ),
         allow_redirects=True,
-    ).text.replace('"', "")
-    token=token.split(':')[2][:-1]
+    )
+    token = json.loads(token._content)
+    token = token["token"]
+  
     time_series_url = "https://api.giovanni.earthdata.nasa.gov/timeseries"
 
     ndf = pd.DataFrame()

--- a/src/tsgettoolbox/functions/ldas.py
+++ b/src/tsgettoolbox/functions/ldas.py
@@ -1142,7 +1142,7 @@ def base_ldas(
         ),
         allow_redirects=True,
     ).text.replace('"', "")
-
+    token=token.split(':')[2][:-1]
     time_series_url = "https://api.giovanni.earthdata.nasa.gov/timeseries"
 
     ndf = pd.DataFrame()


### PR DESCRIPTION
Fixed token-remove expires statement from token

## Summary by Sourcery

Bug Fixes:
- Strip expiry and other metadata from the raw token string before using it in LDAS time series requests.