### PR TITLE
Remove deprecated read_fwf date_parser usage in swtwc

### DIFF
--- a/src/tsgettoolbox/functions/swtwc.py
+++ b/src/tsgettoolbox/functions/swtwc.py
@@ -128,9 +128,6 @@ def get_station_data(station_code, date=None, as_dataframe=False):
         for variable_name in variable_names
     }
 
-    def date_parser(x):
-        return _convert_datetime(x, year)
-
     dataframe = pd.read_fwf(
         sio,
         names=column_names,
@@ -138,9 +135,8 @@ def get_station_data(station_code, date=None, as_dataframe=False):
         index_col=["datetime"],
         na_values=["----"],
         converters=converters,
-        parse_dates=True,
-        date_parser=date_parser,
     )
+    dataframe.index = [_convert_datetime(value, year) for value in dataframe.index]
 
     # parse out rows that are all nans (e.g. end of "current" page)
     dataframe = dataframe[~np.isnan(dataframe.T.sum())]

--- a/src/tsgettoolbox/ulmo/usace/swtwc/core.py
+++ b/src/tsgettoolbox/ulmo/usace/swtwc/core.py
@@ -110,9 +110,6 @@ def get_station_data(station_code, date=None, as_dataframe=False):
         for variable_name in variable_names
     }
 
-    def date_parser(x):
-        _convert_datetime(x, year)
-
     dataframe = pandas.read_fwf(
         sio,
         names=column_names,
@@ -120,9 +117,8 @@ def get_station_data(station_code, date=None, as_dataframe=False):
         index_col=["datetime"],
         na_values=["----"],
         converters=converters,
-        parse_dates=True,
-        date_parser=date_parser,
     )
+    dataframe.index = [_convert_datetime(value, year) for value in dataframe.index]
 
     # parse out rows that are all nans (e.g. end of "current" page)
     dataframe = dataframe[~np.isnan(dataframe.T.sum())]

--- a/tests/test_swtwc.py
+++ b/tests/test_swtwc.py
@@ -1,0 +1,46 @@
+import datetime
+import importlib
+
+
+def _response_with_swtwc_data():
+    text = "\n".join(
+        [
+            "Station ABCD Example Station",
+            "Station Type: RESERVOIR",
+            "Note: Example note",
+            "",
+            f"{'':11}{'STAGE':<10}",
+            f"{'':11}{'FT':<10}",
+            f"{'':11}{'USACE':<10}",
+            "(CST)",
+            f"{'06/09 12:00':<14}{'123.4':>10}",
+        ]
+    )
+
+    class Response:
+        content = f"<html><body><pre>{text}</pre></body></html>".encode()
+
+    return Response()
+
+
+def _assert_station_data(module, monkeypatch):
+    monkeypatch.setattr(
+        module.requests, "get", lambda *args, **kwargs: _response_with_swtwc_data()
+    )
+
+    result = module.get_station_data("ABCD", date="2024-06-09", as_dataframe=True)
+
+    dataframe = result["values"]
+    assert result["code"] == "ABCD"
+    assert dataframe.index[0] == datetime.datetime(2024, 6, 9, 12, 0)
+    assert dataframe.loc[datetime.datetime(2024, 6, 9, 12, 0), "STAGE"] == 123.4
+
+
+def test_functions_swtwc_get_station_data_parses_dates(monkeypatch):
+    module = importlib.import_module("tsgettoolbox.functions.swtwc")
+    _assert_station_data(module, monkeypatch)
+
+
+def test_ulmo_swtwc_get_station_data_parses_dates(monkeypatch):
+    module = importlib.import_module("tsgettoolbox.ulmo.usace.swtwc.core")
+    _assert_station_data(module, monkeypatch)


### PR DESCRIPTION
## Summary
- remove deprecated pandas date_parser arguments from swtwc read_fwf calls
- preserve the existing behavior of applying the requested/current year to SWTWC timestamps that omit a year
- add regression coverage for both the top-level swtwc function module and the ulmo SWTWC module

## Tests
- /Users/liuyu/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile src/tsgettoolbox/functions/swtwc.py src/tsgettoolbox/ulmo/usace/swtwc/core.py tests/test_swtwc.py
- direct parser check with pandas 2.2.3 using mocked SWTWC HTML data

## Summary by Sourcery

Remove deprecated pandas read_fwf date_parser usage in SWTWC data readers while preserving existing datetime behavior and adding regression coverage.

Bug Fixes:
- Preserve application of the requested/current year to SWTWC timestamps that omit a year after removing deprecated date_parser usage.

Enhancements:
- Refactor SWTWC data parsing to set datetime index post-read instead of using deprecated pandas date_parser argument.

Tests:
- Add regression tests for SWTWC get_station_data in both the top-level functions module and the ulmo SWTWC module using mocked HTML response data.